### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,25 @@
 
 Sample project that shows proper modern CMake usage on a dummy library and an executable that uses it.
 Accompanying code to my blog post [It's Time To Do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/)
+
+## Build and Install
+
+As a reference, here is how you can build the library and executable on Ubuntu
+16.04:
+
+```
+sudo apt-get install rapidjson-dev libboost-dev libboost-regex-dev
+cd libjsonutils
+mkdir build && cd build
+export CMAKE_PREFIX_PATH=$HOME/jsonutils
+cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$CMAKE_PREFIX_PATH ..
+make
+# Install to $HOME/jsonutils
+sudo make install
+# Build the executable that links against our library.
+cd ../example_exec
+mkdir build && cd build
+cmake -G "Unix Makefiles" ..
+make
+```
+


### PR DESCRIPTION
To address #4, I successfully built on Ubuntu 16.04 with no difficulty. Similar instructions on the README should work on any system. Tricky part is to get the dependencies right from system package manager.