### PR TITLE
Pimp the modern cmake examples to be modern

### DIFF
--- a/example_exec/CMakeLists.txt
+++ b/example_exec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13..3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13...3.16 FATAL_ERROR)
 project(example_exec VERSION 0.0.1 LANGUAGES CXX)
 
 add_executable(example_exec src/main.cpp)

--- a/example_exec/CMakeLists.txt
+++ b/example_exec/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13..3.16 FATAL_ERROR)
 project(example_exec VERSION 0.0.1 LANGUAGES CXX)
 
-add_executable(example_exec src/main)
+add_executable(example_exec src/main.cpp)
 target_compile_features(example_exec PRIVATE cxx_auto_type)
 
 find_package(JSONUtils 1.0 REQUIRED)

--- a/libjsonutils/CMakeLists.txt
+++ b/libjsonutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13..3.16 FATAL_ERROR)
 project(libjsonutils VERSION 1.0.0 LANGUAGES CXX)
 
 #Make sure that custom modules like FindRapidJSON are found
@@ -6,14 +6,19 @@ list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake)
 
 ##############################################
 # Declare dependencies
-find_package(Boost 1.55 REQUIRED COMPONENTS regex)
-find_package(RapidJSON 1.0 REQUIRED MODULE)
+set(MIN_BOOST_VERSION 1.71)
+find_package(boost_headers ${MIN_BOOST_VERSION} REQUIRED CONFIG)
+find_package(boost_regex ${MIN_BOOST_VERSION} REQUIRED CONFIG)
+
+set(MIN_RAPIDJSON_VERSION 1.1)
+find_package(RapidJSON ${MIN_RAPIDJSON_VERSION} REQUIRED MODULE)
 
 ##############################################
 # Create target and set properties
 
 add_library(jsonutils
     src/json_utils.cpp
+    src/file_utils.h
 )
 
 #Add an alias so that library can be used inside the build tree, e.g. when testing
@@ -29,11 +34,13 @@ target_include_directories(jsonutils
 )
 
 target_compile_features(jsonutils PRIVATE cxx_auto_type)
-target_compile_options(jsonutils PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>)
+target_compile_options(jsonutils PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+    -Wall -Wextra -Wpedantic>)
 
 target_link_libraries(jsonutils
     PUBLIC
-        Boost::boost RapidJSON::RapidJSON
+        Boost::headers RapidJSON::RapidJSON
     PRIVATE
         Boost::regex
 )
@@ -57,12 +64,12 @@ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 #Export the targets to a script
 install(EXPORT jsonutils-targets
-  FILE
-    JSONUtilsTargets.cmake
-  NAMESPACE
-    JSONUtils::
-  DESTINATION
-    ${INSTALL_CONFIGDIR}
+    FILE
+        JSONUtilsTargets.cmake
+    NAMESPACE
+        JSONUtils::
+    DESTINATION
+        ${INSTALL_CONFIGDIR}
 )
 
 #Create a ConfigVersion.cmake file
@@ -92,9 +99,14 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/FindRapidJSON.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/FindRapidJSON.cmake
     COPYONLY)
 
-export(EXPORT jsonutils-targets FILE ${CMAKE_CURRENT_BINARY_DIR}/JSONUtilsTargets.cmake NAMESPACE JSONUtils::)
+export(EXPORT jsonutils-targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/JSONUtilsTargets.cmake
+    NAMESPACE JSONUtils::)
 
 #Register package in user's package registry
 export(PACKAGE JSONUtils)
 
+##############################################
+## Add test
+enable_testing()
 add_subdirectory(test)

--- a/libjsonutils/CMakeLists.txt
+++ b/libjsonutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13..3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13...3.16 FATAL_ERROR)
 project(libjsonutils VERSION 1.0.0 LANGUAGES CXX)
 
 #Make sure that custom modules like FindRapidJSON are found
@@ -10,8 +10,8 @@ set(MIN_BOOST_VERSION 1.71)
 find_package(boost_headers ${MIN_BOOST_VERSION} REQUIRED CONFIG)
 find_package(boost_regex ${MIN_BOOST_VERSION} REQUIRED CONFIG)
 
-set(MIN_RAPIDJSON_VERSION 1.1)
-find_package(RapidJSON ${MIN_RAPIDJSON_VERSION} REQUIRED MODULE)
+set(MIN_RapidJSON_VERSION 1.1)
+find_package(RapidJSON ${MIN_RapidJSON_VERSION} REQUIRED MODULE)
 
 ##############################################
 # Create target and set properties

--- a/libjsonutils/cmake/FindRapidJSON.cmake
+++ b/libjsonutils/cmake/FindRapidJSON.cmake
@@ -6,9 +6,9 @@
 #
 # This will define the following variables
 #
-#    RAPIDJSON_FOUND
-#    RAPIDJSON_VERSION
-#    RAPIDJSON_INCLUDE_DIRS
+#    RapidJSON_FOUND
+#    RapidJSON_VERSION
+#    RapidJSON_INCLUDE_DIRS
 #
 # and the following imported targets
 #
@@ -16,40 +16,35 @@
 #
 # Author: Pablo Arias - pabloariasal@gmail.com
 #
-# clausklein$ cmakelint *.cmake
-# FindRapidJSON.cmake:0: Find modules should use uppercase names;
-#   consider using FindRAPIDJSON.cmake [convention/filename]
-# Total Errors: 1
 
-find_package(PkgConfig REQUIRED)
+find_package(PkgConfig)
 pkg_check_modules(PC_RapidJSON QUIET RapidJSON)
 
-find_path(RAPIDJSON_INCLUDE_DIR
+find_path(RapidJSON_INCLUDE_DIR
     NAMES rapidjson.h
     PATHS ${PC_RapidJSON_INCLUDE_DIRS}
     PATH_SUFFIXES rapidjson
 )
 
-set(RAPIDJSON_VERSION ${PC_RapidJSON_VERSION})
+set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
 
-# NOTE: (cmakelint) All vars should be uppercase! CK
-mark_as_advanced(RAPIDJSON_FOUND RAPIDJSON_INCLUDE_DIR RAPIDJSON_VERSION)
+mark_as_advanced(RapidJSON_FOUND RapidJSON_INCLUDE_DIR RapidJSON_VERSION)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RAPIDJSON
-    REQUIRED_VARS RAPIDJSON_INCLUDE_DIR
-    VERSION_VAR RAPIDJSON_VERSION
+find_package_handle_standard_args(RapidJSON
+    REQUIRED_VARS RapidJSON_INCLUDE_DIR
+    VERSION_VAR RapidJSON_VERSION
 )
 
-if(RAPIDJSON_FOUND)
+if(RapidJSON_FOUND)
     #Set include dirs to parent, to enable includes like #include <rapidjson/document.h>
-    get_filename_component(RAPIDJSON_INCLUDE_DIRS ${RAPIDJSON_INCLUDE_DIR} DIRECTORY)
+    get_filename_component(RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR} DIRECTORY)
 endif()
 
-if(RAPIDJSON_FOUND AND NOT TARGET RapidJSON::RapidJSON)
+if(RapidJSON_FOUND AND NOT TARGET RapidJSON::RapidJSON)
     add_library(RapidJSON::RapidJSON INTERFACE IMPORTED)
     set_target_properties(RapidJSON::RapidJSON PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${RAPIDJSON_INCLUDE_DIRS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${RapidJSON_INCLUDE_DIRS}"
     )
 endif()
 

--- a/libjsonutils/cmake/FindRapidJSON.cmake
+++ b/libjsonutils/cmake/FindRapidJSON.cmake
@@ -1,46 +1,55 @@
 #FindRapidJSON.cmake
-# 
+#
 # Finds the rapidjson library
+#
+# from http://rapidjson.org/
 #
 # This will define the following variables
 #
-#    RapidJSON_FOUND
-#    RapidJSON_INCLUDE_DIRS
+#    RAPIDJSON_FOUND
+#    RAPIDJSON_VERSION
+#    RAPIDJSON_INCLUDE_DIRS
 #
 # and the following imported targets
 #
 #     RapidJSON::RapidJSON
 #
 # Author: Pablo Arias - pabloariasal@gmail.com
+#
+# clausklein$ cmakelint *.cmake
+# FindRapidJSON.cmake:0: Find modules should use uppercase names;
+#   consider using FindRAPIDJSON.cmake [convention/filename]
+# Total Errors: 1
 
-find_package(PkgConfig)
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(PC_RapidJSON QUIET RapidJSON)
 
-find_path(RapidJSON_INCLUDE_DIR
+find_path(RAPIDJSON_INCLUDE_DIR
     NAMES rapidjson.h
     PATHS ${PC_RapidJSON_INCLUDE_DIRS}
     PATH_SUFFIXES rapidjson
 )
 
-set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
+set(RAPIDJSON_VERSION ${PC_RapidJSON_VERSION})
 
-mark_as_advanced(RapidJSON_FOUND RapidJSON_INCLUDE_DIR RapidJSON_VERSION)
+# NOTE: (cmakelint) All vars should be uppercase! CK
+mark_as_advanced(RAPIDJSON_FOUND RAPIDJSON_INCLUDE_DIR RAPIDJSON_VERSION)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RapidJSON
-    REQUIRED_VARS RapidJSON_INCLUDE_DIR
-    VERSION_VAR RapidJSON_VERSION
+find_package_handle_standard_args(RAPIDJSON
+    REQUIRED_VARS RAPIDJSON_INCLUDE_DIR
+    VERSION_VAR RAPIDJSON_VERSION
 )
 
-if(RapidJSON_FOUND)
+if(RAPIDJSON_FOUND)
     #Set include dirs to parent, to enable includes like #include <rapidjson/document.h>
-    get_filename_component(RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR} DIRECTORY)
+    get_filename_component(RAPIDJSON_INCLUDE_DIRS ${RAPIDJSON_INCLUDE_DIR} DIRECTORY)
 endif()
 
-if(RapidJSON_FOUND AND NOT TARGET RapidJSON::RapidJSON)
+if(RAPIDJSON_FOUND AND NOT TARGET RapidJSON::RapidJSON)
     add_library(RapidJSON::RapidJSON INTERFACE IMPORTED)
     set_target_properties(RapidJSON::RapidJSON PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${RapidJSON_INCLUDE_DIRS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${RAPIDJSON_INCLUDE_DIRS}"
     )
 endif()
 

--- a/libjsonutils/cmake/JSONUtilsConfig.cmake.in
+++ b/libjsonutils/cmake/JSONUtilsConfig.cmake.in
@@ -1,18 +1,18 @@
-get_filename_component(JSONUtils_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-include(CMakeFindDependencyMacro)
-
-list(APPEND CMAKE_MODULE_PATH ${JSONUtils_CMAKE_DIR})
-
-# NOTE Had to use find_package because find_dependency does not support COMPONENTS or MODULE until 3.8.0
-
-#find_dependency(Boost 1.55 REQUIRED COMPONENTS regex)
-#find_dependency(RapidJSON 1.0 REQUIRED MODULE)
-find_package(Boost 1.55 REQUIRED COMPONENTS regex)
-find_package(RapidJSON 1.0 REQUIRED MODULE)
+get_filename_component(JSONUTILS_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+#
+# NOTE: We had to use find_package because find_dependency does not support
+# COMPONENTS or MODULE until 3.15.0? CK
+#
+list(APPEND CMAKE_MODULE_PATH ${JSONUTILS_CMAKE_DIR})
+# NOTE: to find FindRapidJSON.cmake
+find_package(RAPIDJSON @MIN_RAPIDJSON_VERSION@ REQUIRED MODULE)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
+include(CMakeFindDependencyMacro)
+find_dependency(boost_regex @MIN_BOOST_VERSION@ REQUIRED CONFIG)
+
 if(NOT TARGET JSONUtils::JSONUtils)
-    include("${JSONUtils_CMAKE_DIR}/JSONUtilsTargets.cmake")
+    include("${JSONUTILS_CMAKE_DIR}/JSONUtilsTargets.cmake")
 endif()
 
-set(JSONUtils_LIBRARIES JSONUtils::JSONUtils)
+set(JSONUTILS_lIBRARIES JSONUtils::JSONUtils)

--- a/libjsonutils/cmake/JSONUtilsConfig.cmake.in
+++ b/libjsonutils/cmake/JSONUtilsConfig.cmake.in
@@ -1,15 +1,12 @@
 get_filename_component(JSONUTILS_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-#
-# NOTE: We had to use find_package because find_dependency does not support
-# COMPONENTS or MODULE until 3.15.0? CK
-#
+include(CMakeFindDependencyMacro)
+
 list(APPEND CMAKE_MODULE_PATH ${JSONUTILS_CMAKE_DIR})
 # NOTE: to find FindRapidJSON.cmake
-find_package(RAPIDJSON @MIN_RAPIDJSON_VERSION@ REQUIRED MODULE)
+find_dependency(RapidJSON @MIN_RapidJSON_VERSION@)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
-include(CMakeFindDependencyMacro)
-find_dependency(boost_regex @MIN_BOOST_VERSION@ REQUIRED CONFIG)
+find_dependency(boost_regex @MIN_BOOST_VERSION@)
 
 if(NOT TARGET JSONUtils::JSONUtils)
     include("${JSONUTILS_CMAKE_DIR}/JSONUtilsTargets.cmake")

--- a/libjsonutils/src/file_utils.h
+++ b/libjsonutils/src/file_utils.h
@@ -4,7 +4,7 @@
 
 namespace jsonutils
 {
-    inline bool doesFileExist(const std::string& file)
+    inline bool doesFileExist(const std::string& /* file */)
     {
         //Simulate that we are checking file existence
         return true;

--- a/libjsonutils/src/json_utils.cpp
+++ b/libjsonutils/src/json_utils.cpp
@@ -1,23 +1,24 @@
+#include "file_utils.h"
+
 #include "jsonutils/json_utils.h"
 
 #include <boost/regex.hpp>
 #include <iostream>
 
-#include <file_utils.h>
 
 namespace jsonutils
 {
     //Extremely poor regex pattern for matching urls
     constexpr auto URL_PATTERN = "(http|https)://(\\w+\\.)+(\\w)/?(\\w+/{0,1})*";
 
-    boost::optional<rapidjson::Document> loadFromUrl(const std::string& url)
+    boost::optional<rapidjson::Document> loadFromUrl(const std::string& /* url */)
     {
         //Download resource and extract message body
         //Return boost::none if something went wrong, e.g. status code >= 300
         rapidjson::Document doc;
         doc.Parse("{\"source\": \"url\"}");
 
-        return doc;
+        return std::move(doc);
     }
 
     boost::optional<rapidjson::Document> loadFromFile(const std::string& file)
@@ -31,7 +32,7 @@ namespace jsonutils
         rapidjson::Document doc;
         doc.Parse("{\"source\": \"file\"}");
 
-        return doc;
+        return std::move(doc);
     }
 
     boost::optional<rapidjson::Document> loadJson(const std::string& location)
@@ -39,11 +40,11 @@ namespace jsonutils
         const boost::regex pattern{URL_PATTERN};
 
         if(boost::regex_match(location, pattern))
-        {                     
+        {
             //Provided location is a URL
             std::cout << "Loading from url" << std::endl;
             return loadFromUrl(location);
-        }                     
+        }
         else
         {
             //Provided location is a filepath

--- a/libjsonutils/src/json_utils.cpp
+++ b/libjsonutils/src/json_utils.cpp
@@ -1,10 +1,9 @@
-#include "file_utils.h"
-
 #include "jsonutils/json_utils.h"
 
 #include <boost/regex.hpp>
 #include <iostream>
 
+#include "file_utils.h"
 
 namespace jsonutils
 {
@@ -18,6 +17,7 @@ namespace jsonutils
         rapidjson::Document doc;
         doc.Parse("{\"source\": \"url\"}");
 
+        // force-move into the optional, as some compilers don't do this automatically
         return std::move(doc);
     }
 
@@ -32,6 +32,7 @@ namespace jsonutils
         rapidjson::Document doc;
         doc.Parse("{\"source\": \"file\"}");
 
+        // force-move into the optional, as some compilers don't do this automatically
         return std::move(doc);
     }
 

--- a/libjsonutils/test/CMakeLists.txt
+++ b/libjsonutils/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # see /opt/local/share/cmake-3.16/Modules/FindGTest.cmake
-find_package(GTEST QUIET)
+find_package(GTest QUIET)
 
+# NOTE: the upper case GTEST! CK
 if(NOT GTEST_FOUND)
   # Download and unpack googletest at configure time
   # but only if needed! CK
@@ -27,7 +28,7 @@ if(NOT GTEST_FOUND)
     EXCLUDE_FROM_ALL)
 endif()
 
-# Now simply link against gtest or gtest_main as needed. Eg
+# Now simply link against GTest::Main as needed. Eg
 add_executable(json_utils_test src/main.cpp)
 target_compile_features(json_utils_test PRIVATE cxx_auto_type)
 target_link_libraries(json_utils_test GTest::Main JSONUtils::jsonutils)

--- a/libjsonutils/test/CMakeLists.txt
+++ b/libjsonutils/test/CMakeLists.txt
@@ -1,25 +1,36 @@
-# Download and unpack googletest at configure time
-configure_file(${CMAKE_SOURCE_DIR}/cmake/GoogleTest-CMakeLists.txt.in ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
-endif()
+# see /opt/local/share/cmake-3.16/Modules/FindGTest.cmake
+find_package(GTEST QUIET)
 
-# Add googletest directly to our build. This defines
-# the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
-                 ${CMAKE_BINARY_DIR}/googletest-build
-                 EXCLUDE_FROM_ALL)
+if(NOT GTEST_FOUND)
+  # Download and unpack googletest at configure time
+  # but only if needed! CK
+  configure_file(${CMAKE_SOURCE_DIR}/cmake/GoogleTest-CMakeLists.txt.in
+    ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
+
+  # Add googletest directly to our build. This defines
+  # the gtest and gtest_main targets.
+  add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+    ${CMAKE_BINARY_DIR}/googletest-build
+    EXCLUDE_FROM_ALL)
+endif()
 
 # Now simply link against gtest or gtest_main as needed. Eg
 add_executable(json_utils_test src/main.cpp)
 target_compile_features(json_utils_test PRIVATE cxx_auto_type)
-target_link_libraries(json_utils_test gtest_main JSONUtils::jsonutils)
+target_link_libraries(json_utils_test GTest::Main JSONUtils::jsonutils)
+
+add_test(NAME json_utils_test
+    COMMAND json_utils_test)

--- a/libjsonutils/test/src/main.cpp
+++ b/libjsonutils/test/src/main.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
 #include <jsonutils/json_utils.h>
+
+#include <gtest/gtest.h>
 
 TEST(JsonUtilsTest, loadFromFile)
 {

--- a/libjsonutils/test/src/main.cpp
+++ b/libjsonutils/test/src/main.cpp
@@ -1,6 +1,5 @@
-#include <jsonutils/json_utils.h>
-
 #include <gtest/gtest.h>
+#include <jsonutils/json_utils.h>
 
 TEST(JsonUtilsTest, loadFromFile)
 {


### PR DESCRIPTION
Prevent most cmakelint warnings.
Prevent to download gtest if found on build host.
Use modern boost version 1.71.0
Use ctest too.

Note: the test fails!